### PR TITLE
Update AWS SDKs nuget spec upper bound to 4.0

### DIFF
--- a/AWS.TraceListener.nuspec
+++ b/AWS.TraceListener.nuspec
@@ -11,8 +11,8 @@
     <tags>AWS Amazon cloud</tags>
     <iconUrl>http://media.amazonwebservices.com/aws_singlebox_01.png</iconUrl>
     <dependencies>
-	  <dependency id="AWSSDK.DynamoDBv2" version="[3.1.0.0, 3.2)" />
-	  <dependency id="AWSSDK.Core" version="[3.1.3.1, 3.2)" />
+	  <dependency id="AWSSDK.DynamoDBv2" version="[3.1.0.0, 4.0)" />
+	  <dependency id="AWSSDK.Core" version="[3.1.3.1, 4.0)" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
To allow usage of AWSSDKs with version less than equal to 4.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
